### PR TITLE
Add TransferLock

### DIFF
--- a/extensions/token/balance_account.go
+++ b/extensions/token/balance_account.go
@@ -118,6 +118,11 @@ func (s *AccountStore) BurnLock(ctx router.Context, id *LockId) error {
 	return nil
 }
 
+// todo: add TransferLock implementation
+func (u *AccountStore) TransferLock(ctx router.Context, id *LockId, transfer *TransferOperation) error {
+	return nil
+}
+
 func (s *AccountStore) BurnAllLock(router.Context, *BalanceOperation) error {
 	return nil
 }

--- a/extensions/token/balance_store.go
+++ b/extensions/token/balance_store.go
@@ -23,6 +23,7 @@ type (
 		Lock(router.Context, *BalanceOperation) (*LockId, error)
 		Unlock(router.Context, *LockId) error
 		BurnLock(router.Context, *LockId) error
+		TransferLock(router.Context, *LockId, *TransferOperation) error
 		LockAll(router.Context, *BalanceOperation) error
 		BurnAllLock(router.Context, *BalanceOperation) error
 	}


### PR DESCRIPTION
Allow to transfer locked tokens between accounts.
Only the utxo model is supported so far.

Signed-off-by: olaeseane <olaesean@gmail.com>