### PR TITLE
Expose additional protojson marshal options. 

### DIFF
--- a/serialize/serializer.go
+++ b/serialize/serializer.go
@@ -13,9 +13,12 @@ type (
 	TargetType     string
 
 	GenericSerializer struct {
-		Supports      []SuppportedType
-		Target        TargetType
-		UseProtoNames bool // to use proto field name instead of lowerCamelCase name in JSON field names
+		Supports        []SuppportedType
+		Target          TargetType
+		UseProtoNames   bool // to use proto field name instead of lowerCamelCase name in JSON field names
+		UseEnumNumbers  bool // to use numbers instead of strings for enums
+		EmitUnpopulated bool // Emit the default value for unpopulated feilds
+
 	}
 
 	StringSerializer struct {
@@ -46,9 +49,11 @@ var (
 	}
 
 	PreferJSONSerializer = &GenericSerializer{
-		Supports:      []SuppportedType{AnyType},
-		Target:        PreferJSON,
-		UseProtoNames: true,
+		Supports:        []SuppportedType{AnyType},
+		Target:          PreferJSON,
+		UseProtoNames:   true,
+		UseEnumNumbers:  true,
+		EmitUnpopulated: true,
 	}
 	KeySerializer = &StringSerializer{}
 
@@ -62,7 +67,7 @@ func (g *GenericSerializer) ToBytesFrom(entry interface{}) ([]byte, error) {
 
 	case proto.Message:
 		if g.Target == PreferJSON {
-			mo := &protojson.MarshalOptions{UseProtoNames: g.UseProtoNames}
+			mo := &protojson.MarshalOptions{UseProtoNames: g.UseProtoNames, UseEnumNumbers: g.UseEnumNumbers, EmitUnpopulated: g.EmitUnpopulated}
 			return JSONProtoMarshal(entryType, mo)
 		} else {
 			return BinaryProtoMarshal(entryType)


### PR DESCRIPTION
This is in relation to issue #31 and storing the state a json objects. This exposes two additional options for json serialization and enables them by default for the json sterilization. The first option has it encode the enums as an int instead of a string. This will reduce the size of the objects stored in the ledger. The second option is to enable it to encode default values when translating the proto to json. This will ensure that the objects in the CouchDB will have the expected shape so that rich queries can be ran on the world state db for objects that have default values. 